### PR TITLE
Add MTCLocal.xml to GitIgnore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ bld/
 [Bb]in/
 [Oo]bj/
 [Ll]og/
+MTC_Local.xml
 
 # Visual Studio 2015 cache/options directory
 .vs/


### PR DESCRIPTION
Local file created from Metrology Taxonomy Catalog is be uploaded to GitHub and should not be. This will prevent it from uploading and after this is checked in I can remove it from the code files.